### PR TITLE
Docker: further image size reduction by specifying Java modules

### DIFF
--- a/docker/Dockerfile.tpl
+++ b/docker/Dockerfile.tpl
@@ -33,7 +33,7 @@ RUN apt-get -qq update && apt-get -qq install -y gnupg \
 	&& echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
 	&& apt-get -qq update \
 	&& apt-get -qq install -y temurin-11-jdk \
-	&& jlink --add-modules ALL-MODULE-PATH --output /java/ --strip-debug --no-man-pages --compress=2 \
+	&& jlink --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,jdk.crypto.cryptoki,jdk.jdi,jdk.management,jdk.unsupported --output /java/ --strip-debug --no-man-pages --compress=2 \
 	&& apt-get -qq purge -y gnupg temurin-11-jdk \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/aarch64.Dockerfile
+++ b/docker/aarch64.Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -qq update && apt-get -qq install -y gnupg \
 	&& echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
 	&& apt-get -qq update \
 	&& apt-get -qq install -y temurin-11-jdk \
-	&& jlink --add-modules ALL-MODULE-PATH --output /java/ --strip-debug --no-man-pages --compress=2 \
+	&& jlink --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,jdk.crypto.cryptoki,jdk.jdi,jdk.management,jdk.unsupported --output /java/ --strip-debug --no-man-pages --compress=2 \
 	&& apt-get -qq purge -y gnupg temurin-11-jdk \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/amd64.Dockerfile
+++ b/docker/amd64.Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -qq update && apt-get -qq install -y gnupg \
 	&& echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
 	&& apt-get -qq update \
 	&& apt-get -qq install -y temurin-11-jdk \
-	&& jlink --add-modules ALL-MODULE-PATH --output /java/ --strip-debug --no-man-pages --compress=2 \
+	&& jlink --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,jdk.crypto.cryptoki,jdk.jdi,jdk.management,jdk.unsupported --output /java/ --strip-debug --no-man-pages --compress=2 \
 	&& apt-get -qq purge -y gnupg temurin-11-jdk \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/armv7hf.Dockerfile
+++ b/docker/armv7hf.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get -qq update && apt-get -qq install -y gnupg \
 	&& echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
 	&& apt-get -qq update \
 	&& apt-get -qq install -y temurin-11-jdk \
-	&& jlink --add-modules ALL-MODULE-PATH --output /java/ --strip-debug --no-man-pages --compress=2 \
+	&& jlink --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,jdk.crypto.cryptoki,jdk.jdi,jdk.management,jdk.unsupported --output /java/ --strip-debug --no-man-pages --compress=2 \
 	&& apt-get -qq purge -y gnupg temurin-11-jdk \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,27 +1,28 @@
-openseedbox-postgres:
-  image: postgres
-  volumes:
-    - /var/lib/pgsql
-  environment:
-    - POSTGRES_USER=openseedbox
-    - POSTGRES_PASSWORD=openseedbox
-    - POSTGRES_DB=openseedbox
+services:
+  openseedbox-postgres:
+    image: postgres
+    volumes:
+      - /var/lib/pgsql
+    environment:
+      - POSTGRES_USER=openseedbox
+      - POSTGRES_PASSWORD=openseedbox
+      - POSTGRES_DB=openseedbox
 
-openseedbox-node1:
-  image: openseedbox/server
-  volumes:
-    - /media/openseedbox
-  ports:
-    - "444:443"
-  environment:
-    - OPENSEEDBOX_API_KEY
+  openseedbox-node1:
+    image: openseedbox/server
+    volumes:
+      - /media/openseedbox
+    ports:
+      - "444:443"
+    environment:
+      - OPENSEEDBOX_API_KEY
 
-openseedbox:
-  image: openseedbox/client
-  links:
-    - openseedbox-postgres:openseedboxdb
-    - openseedbox-node1:node1
-  ports:
-    - "443:443"
-  environment:
-    - GOOGLE_CLIENTID
+  openseedbox:
+    image: openseedbox/client
+    links:
+      - openseedbox-postgres:openseedboxdb
+      - openseedbox-node1:node1
+    ports:
+      - "443:443"
+    environment:
+      - GOOGLE_CLIENTID


### PR DESCRIPTION
As discussed in #77 the image size can be further reduced by specifying Java modules which the project uses instead of the ALL-MODULE-PATH option.

E.g. for aarch64/arm64:

```
$ docker image ls -f reference='openseedbox/*'
REPOSITORY              TAG       IMAGE ID       CREATED       SIZE
openseedbox/server-v2   aarch64   c6af25e68d7e   2 hours ago   403MB
openseedbox/client-v2   aarch64   9eddc92d5f6d   2 hours ago   399MB
openseedbox/server      aarch64   f37c047d964d   2 days ago    438MB
openseedbox/client      aarch64   212c531ee480   11 days ago   433MB
```