### PR TITLE
models/Torrent: siena.Text annotation on text columns (#117)

### DIFF
--- a/app/com/openseedbox/models/Torrent.java
+++ b/app/com/openseedbox/models/Torrent.java
@@ -29,7 +29,7 @@ public class Torrent extends ModelBase implements ITorrent {
 	@Column("downloaded_bytes") private long downloadedBytes;
 	@Column("uploaded_bytes") private long uploadedBytes;	
 	@Column("total_size_bytes") private long totalSizeBytes;
-	@Column("zip_download_link") private String zipDownloadLink;
+	@Column("zip_download_link") @Text private String zipDownloadLink;
 	private String error;
 	private TorrentState state;
 	@Column("create_date")

--- a/app/com/openseedbox/models/Torrent.java
+++ b/app/com/openseedbox/models/Torrent.java
@@ -14,13 +14,14 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import siena.Column;
 import siena.Table;
+import siena.Text;
 
 @Table("torrent")
 @UseAccessor
 public class Torrent extends ModelBase implements ITorrent {
 	
 	@Column("torrent_hash") private String torrentHash;	
-	private String name;	
+	@Text private String name;
 	@Column("metadata_percent_complete") private double metadataPercentComplete;
 	@Column("percent_complete") private double percentComplete;
 	@Column("download_speed_bytes") private long downloadSpeedBytes;

--- a/app/com/openseedbox/models/Torrent.java
+++ b/app/com/openseedbox/models/Torrent.java
@@ -30,7 +30,7 @@ public class Torrent extends ModelBase implements ITorrent {
 	@Column("uploaded_bytes") private long uploadedBytes;	
 	@Column("total_size_bytes") private long totalSizeBytes;
 	@Column("zip_download_link") @Text private String zipDownloadLink;
-	private String error;
+	@Text private String error;
 	private TorrentState state;
 	@Column("create_date")
 	private Date createDate;

--- a/test/com/openseedbox/models/TestTorrent.java
+++ b/test/com/openseedbox/models/TestTorrent.java
@@ -1,0 +1,49 @@
+package com.openseedbox.models;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+import play.test.UnitTest;
+
+public class TestTorrent extends UnitTest {
+
+	private String chartToAppend = "a";
+
+	String longName(int length) {
+		StringBuilder sb = new StringBuilder("This name is a little longer than ");
+		sb.append(length).append(StringUtils.repeat(chartToAppend, length));
+		return sb.toString();
+	}
+
+	@Test
+	public void testTorrentNameShort() {
+		Torrent t = new Torrent();
+		t.setName("This is just a short name");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentName200() {
+		Torrent t = new Torrent();
+		t.setName(longName(200));
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentName5000() {
+		Torrent t = new Torrent();
+		t.setName(longName(5000));
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentName10000() {
+		Torrent t = new Torrent();
+		t.setName(longName(10000));
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.insertOrUpdate();
+	}
+}

--- a/test/com/openseedbox/models/TestTorrent.java
+++ b/test/com/openseedbox/models/TestTorrent.java
@@ -10,10 +10,19 @@ public class TestTorrent extends UnitTest {
 	private String chartToAppend = "a";
 
 	String longName(int length) {
-		StringBuilder sb = new StringBuilder("This name is a little longer than ");
+		return longString("This name is a little longer than ", length);
+	}
+
+	String longLink(int length) {
+		return longString("my-awesome-openseedbox-backend-app-127-0-0-1.nip.io:9001/download/zip/", length);
+	}
+
+	String longString(String start, int length) {
+		StringBuilder sb = new StringBuilder(start);
 		sb.append(length).append(StringUtils.repeat(chartToAppend, length));
 		return sb.toString();
 	}
+
 
 	@Test
 	public void testTorrentNameShort() {
@@ -44,6 +53,42 @@ public class TestTorrent extends UnitTest {
 		Torrent t = new Torrent();
 		t.setName(longName(10000));
 		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentZipDownloadLink100() {
+		Torrent t = new Torrent();
+		t.setName("Longer");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setZipDownloadLink(longLink(100));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentZipDownloadLink200() {
+		Torrent t = new Torrent();
+		t.setName("Even longer");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setZipDownloadLink(longLink(200));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentZipDownloadLink5000() {
+		Torrent t = new Torrent();
+		t.setName("The longest");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setZipDownloadLink(longLink(5000));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentZipDownloadLink10000() {
+		Torrent t = new Torrent();
+		t.setName("It's over 9000!");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setZipDownloadLink(longLink(10000));
 		t.insertOrUpdate();
 	}
 }

--- a/test/com/openseedbox/models/TestTorrent.java
+++ b/test/com/openseedbox/models/TestTorrent.java
@@ -17,6 +17,10 @@ public class TestTorrent extends UnitTest {
 		return longString("my-awesome-openseedbox-backend-app-127-0-0-1.nip.io:9001/download/zip/", length);
 	}
 
+	String longError(int length) {
+		return longString("JsonSyntaxException occurred : java.lang.IllegalStateException: Expected NUMBER but was BOOLEAN at path $.trackerStats[0].lastScrapeTimedOut\n", length);
+	}
+
 	String longString(String start, int length) {
 		StringBuilder sb = new StringBuilder(start);
 		sb.append(length).append(StringUtils.repeat(chartToAppend, length));
@@ -89,6 +93,42 @@ public class TestTorrent extends UnitTest {
 		t.setName("It's over 9000!");
 		t.setHashString(DigestUtils.sha1Hex(t.getName()));
 		t.setZipDownloadLink(longLink(10000));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentError100() {
+		Torrent t = new Torrent();
+		t.setName("Simple error");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setErrorMessage(longError(100));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentError200() {
+		Torrent t = new Torrent();
+		t.setName("Longer error");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setErrorMessage(longError(200));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentError5000() {
+		Torrent t = new Torrent();
+		t.setName("The longest error");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setErrorMessage(longError(5000));
+		t.insertOrUpdate();
+	}
+
+	@Test
+	public void testTorrentError10000() {
+		Torrent t = new Torrent();
+		t.setName("It's over 9000!");
+		t.setHashString(DigestUtils.sha1Hex(t.getName()));
+		t.setErrorMessage(longError(10000));
 		t.insertOrUpdate();
 	}
 }


### PR DESCRIPTION
Add a few `@Siena.Text` to `com.openseedbox.models.Torrent` to avoid such `ERROR: value too long for type character varying(255)` errors.

Fixes: #117 