### PR TITLE
views/client: show peer's progress in the Torrent Info view (#121)

### DIFF
--- a/app/com/openseedbox/backend/node/NodePeer.java
+++ b/app/com/openseedbox/backend/node/NodePeer.java
@@ -11,6 +11,7 @@ public class NodePeer implements IPeer {
 	private long downloadRateBytes;
 	private long uploadRateBytes;
 	private String ipAddress;
+	private double percentComplete;
 
 	public String getClientName() {
 		return clientName;
@@ -68,4 +69,11 @@ public class NodePeer implements IPeer {
 		this.ipAddress = ipAddress;
 	}
 	
+	public double getProgress() {
+		return percentComplete;
+	};
+
+	public void setProgress(double progress) {
+		this.percentComplete = progress;
+	}
 }

--- a/app/views/client/torrent-info.html
+++ b/app/views/client/torrent-info.html
@@ -77,6 +77,7 @@
 						<th>Address</th>
 						<th>Client</th>
 						<th>Secure</th>
+						<th>Done</th>
 						<th>Down (kb/s)</th>
 						<th>Up (kb/s)</th>
 					</tr>				
@@ -87,6 +88,10 @@
 						<td>
 							#{if peer.encryptionEnabled}<span class="text-success">yes</span>#{/if}
 							#{else}<span class="text-error">no</span>#{/else}
+						</td>
+						<td>
+							#{if peer.percentComplete > -1}${String.format("%.2f", peer.percentComplete * 100)}%#{/if}
+							#{else}n/a#{/else}
 						</td>
 						<td>${Util.getBestRate(peer.downloadRateBytes)}/s</td>
 						<td>${Util.getBestRate(peer.uploadRateBytes)}/s</td>


### PR DESCRIPTION
Show the torrent peer's progress as a percent (%) in a new "Done" column between the "Secure" and "Down (kb/s)" columns.

See openseedbox/openseedbox-common@731260f14d43f1679132cf4d17d219aa563cf8df

Fixes: #121 